### PR TITLE
Update GPIO for Linux 3.17+

### DIFF
--- a/mcp2210-gpio.c
+++ b/mcp2210-gpio.c
@@ -117,14 +117,8 @@ int mcp2210_gpio_probe(struct mcp2210_device *dev)
 
 void mcp2210_gpio_remove(struct mcp2210_device *dev)
 {
-	int ret;
-
 	mcp2210_info();
-	ret = gpiochip_remove(&dev->gpio);
-	if (ret) {
-		mcp2210_err("gpiochip_remove() failed with %de", ret);
-		return;
-	}
+	gpiochip_remove(&dev->gpio);
 	dev->s.is_gpio_probed = 0;
 }
 

--- a/mcp2210-gpio.c
+++ b/mcp2210-gpio.c
@@ -34,6 +34,10 @@
 # define HAVE_SET_DEBOUNCE 1
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
+# define HAVE_SET_EXPORTED 1
+#endif
+
 //static int  request	    (struct gpio_chip *chip, unsigned offset);
 //static void free	    (struct gpio_chip *chip, unsigned offset);
 #ifdef HAVE_GET_DIRECTION
@@ -98,7 +102,11 @@ int mcp2210_gpio_probe(struct mcp2210_device *dev)
 	gpio->names		= (void*)dev->names; /* older kernels use char** */
 	gpio->can_sleep		= 1; /* we have to make them sleep because we
 					need to do an URB */
+#ifdef HAVE_SET_EXPORTED
 	gpio->exported		= 0;
+#else
+	gpio->cdev = NULL;
+#endif
 
 
 	ret = gpiochip_add(gpio);


### PR DESCRIPTION
Since Linux 3.17-rc2, gpiochip_remove() returns void. The update is trivial.