### PR TITLE
Fix compilation for kernel 4.4.0

### DIFF
--- a/mcp2210-irq.c
+++ b/mcp2210-irq.c
@@ -194,9 +194,16 @@ void _mcp2210_irq_do_gpio(struct mcp2210_device *dev, u16 old_val, u16 new_val)
 			continue;
 
 		if (pin->irq_type & (new_pin_val ? up_mask : down_mask)) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
 			int virq = dev->irq_base + pin->irq;
+#endif
 			struct irq_desc *desc = dev->irq_descs[pin->irq];
+			//handle_simple_irq(virq, desc);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+			handle_simple_irq(desc);
+#else
 			handle_simple_irq(virq, desc);
+#endif
 		}
 	}
 }
@@ -212,7 +219,11 @@ void _mcp2210_irq_do_intr_counter(struct mcp2210_device *dev, u16 count)
 	/* We're discarding count and just letting handlers know that at least
 	 * one interrupt occured. Maybe needs a mechanism to let consumers
 	 * know the count? */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+	handle_simple_irq(desc);
+#else
 	handle_simple_irq(dev->irq_base + pin->irq, desc);
+#endif
 }
 
 static void warn_poll_past_due(struct mcp2210_device *dev, unsigned long now,


### PR DESCRIPTION
This fixes following compilation error.

```  CC [M]  /home/ami/repos/mcp2210-linux/mcp2210-irq.o
/home/ami/repos/mcp2210-linux/mcp2210-irq.c: In function ‘_mcp2210_irq_do_gpio’:
/home/ami/repos/mcp2210-linux/mcp2210-irq.c:199:22: error: passing argument 1 of                                                                                         ‘handle_simple_irq’ makes pointer from integer without a cast [-Werror=int-conv                                                                                        ersion]
    handle_simple_irq(virq, desc);
                      ^
In file included from ./arch/x86/include/asm/hardirq.h:5:0,
                 from include/linux/hardirq.h:8,
                 from include/linux/interrupt.h:12,
                 from include/linux/usb.h:15,
                 from /home/ami/repos/mcp2210-linux/mcp2210.h:42,
                 from /home/ami/repos/mcp2210-linux/mcp2210-irq.c:21:
include/linux/irq.h:471:13: note: expected ‘struct irq_desc _’ but argument is o                                                                                        f type ‘int’
 extern void handle_simple_irq(struct irq_desc *desc);
             ^
/home/ami/repos/mcp2210-linux/mcp2210-irq.c:199:4: error: too many arguments to                                                                                         function ‘handle_simple_irq’
    handle_simple_irq(virq, desc);
    ^
In file included from ./arch/x86/include/asm/hardirq.h:5:0,
                 from include/linux/hardirq.h:8,
                 from include/linux/interrupt.h:12,
                 from include/linux/usb.h:15,
                 from /home/ami/repos/mcp2210-linux/mcp2210.h:42,
                 from /home/ami/repos/mcp2210-linux/mcp2210-irq.c:21:
include/linux/irq.h:471:13: note: declared here
 extern void handle_simple_irq(struct irq_desc *desc);
             ^
/home/ami/repos/mcp2210-linux/mcp2210-irq.c: In function ‘_mcp2210_irq_do_intr_c                                                                                        ounter’:
/home/ami/repos/mcp2210-linux/mcp2210-irq.c:215:20: error: passing argument 1 of                                                                                         ‘handle_simple_irq’ makes pointer from integer without a cast [-Werror=int-conv                                                                                        ersion]
  handle_simple_irq(dev->irq_base + pin->irq, desc);
                    ^
In file included from ./arch/x86/include/asm/hardirq.h:5:0,
                 from include/linux/hardirq.h:8,
                 from include/linux/interrupt.h:12,
                 from include/linux/usb.h:15,
                 from /home/ami/repos/mcp2210-linux/mcp2210.h:42,
                 from /home/ami/repos/mcp2210-linux/mcp2210-irq.c:21:
include/linux/irq.h:471:13: note: expected ‘struct irq_desc *’ but argument is o                                                                                        f type ‘int’
 extern void handle_simple_irq(struct irq_desc *desc);
             ^
/home/ami/repos/mcp2210-linux/mcp2210-irq.c:215:2: error: too many arguments to                                                                                         function ‘handle_simple_irq’
  handle_simple_irq(dev->irq_base + pin->irq, desc);
  ^
In file included from ./arch/x86/include/asm/hardirq.h:5:0,
                 from include/linux/hardirq.h:8,
                 from include/linux/interrupt.h:12,
                 from include/linux/usb.h:15,
                 from /home/ami/repos/mcp2210-linux/mcp2210.h:42,
                 from /home/ami/repos/mcp2210-linux/mcp2210-irq.c:21:
include/linux/irq.h:471:13: note: declared here
 extern void handle_simple_irq(struct irq_desc *desc);
             ^
cc1: all warnings being treated as errors
scripts/Makefile.build:258: recipe for target '/home/ami/repos/mcp2210-linux/mcp                                                                                        2210-irq.o' failed
make[2]: *_\* [/home/ami/repos/mcp2210-linux/mcp2210-irq.o] Error 1
Makefile:1403: recipe for target '_module_/home/ami/repos/mcp2210-linux' failed
make[1]: **\* [_module_/home/ami/repos/mcp2210-linux] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-4.4.0-36-generic'
Makefile:31: recipe for target 'modules' failed
make: **\* [modules] Error 2```
