### PR TITLE
Build fixes

### DIFF
--- a/mcp2210-ctl.c
+++ b/mcp2210-ctl.c
@@ -355,19 +355,23 @@ static int ctl_complete_urb(struct mcp2210_cmd *cmd_head)
 					    rep->body.gpio);
 		dev->s.chip_settings.gpio_value = rep->body.gpio;
 		mcp2210_info("MCP2210_CMD_GET_PIN_VALUE");
+#ifdef CONFIG_MCP2210_IRQ
 		dev->last_poll_gpio = dev->eps[EP_IN].submit_time;
+#endif
 		break;
 	case MCP2210_CMD_SET_PIN_VALUE:
 		dev->s.chip_settings.gpio_value = req->body.gpio;
 		mcp2210_info("MCP2210_CMD_SET_PIN_VALUE");
 		break;
 	case MCP2210_CMD_GET_INTERRUPTS:
+#ifdef CONFIG_MCP2210_IRQ
 		/* notify interrupt controller */
 		if (dev->is_irq_probed)
 			mcp2210_irq_do_intr_counter(dev, rep->body.interrupt_event_counter);
 		dev->interrupt_event_counter = req->body.interrupt_event_counter;
 		mcp2210_info("MCP2210_CMD_GET_INTERRUPTS");
 		dev->last_poll_intr = jiffies;
+#endif /* CONFIG_MCP2210_IRQ */
 		break;
 
 	default:

--- a/mcp2210-lib.c
+++ b/mcp2210-lib.c
@@ -1920,8 +1920,8 @@ void dump_spi_transfer(const char *level, unsigned indent, const char *start,
 	       "%s  .tx_buf        = %p\n"
 	       "%s  .rx_buf        = %p\n"
 	       "%s  .len           = %u\n"
-	       "%s  .tx_dma        = %p\n"
-	       "%s  .rx_dma        = %p\n"
+	       "%s  .tx_dma        = %pad\n"
+	       "%s  .rx_dma        = %pad\n"
 	       "%s  .cs_change     = %u\n"
 	       "%s  .bits_per_word = %hhu\n"
 	       "%s  .delay_usecs   = %hu\n"
@@ -1932,8 +1932,8 @@ void dump_spi_transfer(const char *level, unsigned indent, const char *start,
 	       ind, xfer->tx_buf,
 	       ind, xfer->rx_buf,
 	       ind, xfer->len,
-	       ind, (void*)xfer->tx_dma,
-	       ind, (void*)xfer->tx_dma,
+	       ind, &xfer->tx_dma,
+	       ind, &xfer->tx_dma,
 	       ind, xfer->cs_change,
 	       ind, xfer->bits_per_word,
 	       ind, xfer->delay_usecs,


### PR DESCRIPTION
This fixes two build issues:
- logging an invalid values instead of DMA addresses by dump_spi_transfer();
- broken build when CONFIG_MCP2210_IRQ is not defined in out-of-tree-autoconf.h.