### PR TITLE
Fix endless re-transmissions when num_xfers > 1

### DIFF
--- a/mcp2210-spi.c
+++ b/mcp2210-spi.c
@@ -803,7 +803,7 @@ static int spi_complete_urb(struct mcp2210_cmd *cmd_head)
 		}
 
 		mcp2210_info("Starting next spi_transfer...");
-		xfer = list_entry(next, struct spi_transfer,
+		cmd->xfer = list_entry(next, struct spi_transfer,
 				  transfer_list);
 		cmd->pos = 0;
 		cmd->pending_bytes = 0;


### PR DESCRIPTION
Single xfer with 2 bytes: OK
mcp2210-util -D /dev/spidevX spi 9800  // SPI_IOC_MESSAGE(1)

Two xfers with 1 byte: ERROR endless transmission
mcp2210-util -D /dev/spidevX spi 98,00  // SPI_IOC_MESSAGE(2)

cmd->xfer is not updated after the first xfer finished => endless transmission

Looks like commit c4f83f1fc525ac75874db9ecbdbe285a14368afe introduced this issue:
https://github.com/daniel-santos/mcp2210-linux/commit/c4f83f1fc525ac75874db9ecbdbe285a14368afe#diff-0215cfa293de9d1a72422d837fa2be64c49391dfb2835b99adb31403298f0206L772